### PR TITLE
Add support for setting company logo

### DIFF
--- a/exportdirectory/base.py
+++ b/exportdirectory/base.py
@@ -21,25 +21,38 @@ class BaseAPIClient:
         self.api_key = api_key
 
     def put(self, url, data):
-        return self.request("PUT", url, "application/json", data=data)
+        return self.request(
+            "PUT", url, "application/json", data=json.dumps(data)
+        )
 
-    def patch(self, url, data):
-        return self.request("PATCH", url, "application/json", data=data)
+    def patch(self, url, data, files={}):
+        if files:
+            response = self.request(
+                "PATCH", url, "multipart/form-data", data=data, files=files
+            )
+        else:
+            response = self.request(
+                "PATCH", url, "application/json", data=json.dumps(data),
+            )
+        return response
 
     def get(self, url, params=None):
         return self.request("GET", url, params=params)
 
     def post(self, url, data):
-        return self.request("POST", url, "application/json", data=data)
+        return self.request(
+            "POST", url, "application/json", data=json.dumps(data)
+        )
 
     def delete(self, url, data=None):
         return self.request("DELETE", url)
 
-    def request(self, method, url, content_type=None, data=None, params=None):
+    def request(
+        self, method, url, content_type=None, data=None, params=None,
+        files=None
+    ):
 
         logger.debug("API request {} {}".format(method, url))
-
-        payload = json.dumps(data)
 
         headers = {
             "User-agent": "EXPORT-DIRECTORY-API-CLIENT/{}".format(__version__),
@@ -57,8 +70,9 @@ class BaseAPIClient:
                 method=method,
                 url=url,
                 headers=headers,
-                data=payload,
-                params=params
+                data=data,
+                params=params,
+                files=files,
             )
             if not response.ok:
                 logger.error(

--- a/exportdirectory/base.py
+++ b/exportdirectory/base.py
@@ -22,30 +22,43 @@ class BaseAPIClient:
 
     def put(self, url, data):
         return self.request(
-            "PUT", url, "application/json", data=json.dumps(data)
+            url=url,
+            method="PUT",
+            content_type="application/json",
+            data=json.dumps(data)
         )
 
-    def patch(self, url, data, files={}):
+    def patch(self, url, data, files=None):
         if files:
             response = self.request(
-                "PATCH", url, "multipart/form-data", data=data, files=files
+                url=url,
+                method="PATCH",
+                content_type="multipart/form-data",
+                data=data,
+                files=files,
             )
         else:
             response = self.request(
-                "PATCH", url, "application/json", data=json.dumps(data),
+                url=url,
+                method="PATCH",
+                content_type="application/json",
+                data=json.dumps(data),
             )
         return response
 
     def get(self, url, params=None):
-        return self.request("GET", url, params=params)
+        return self.request(url=url, method="GET", params=params)
 
     def post(self, url, data):
         return self.request(
-            "POST", url, "application/json", data=json.dumps(data)
+            url=url,
+            method="POST",
+            content_type="application/json",
+            data=json.dumps(data),
         )
 
     def delete(self, url, data=None):
-        return self.request("DELETE", url)
+        return self.request(url=url, method="DELETE")
 
     def request(
         self, method, url, content_type=None, data=None, params=None,

--- a/exportdirectory/company.py
+++ b/exportdirectory/company.py
@@ -4,9 +4,13 @@ from exportdirectory.base import BaseAPIClient
 class CompanyAPIClient(BaseAPIClient):
 
     def update_profile(self, id, data):
+        files = {}
+        if 'logo' in data:
+            files['logo'] = data.pop('logo')
         return self.patch(
             '/company/{id}/'.format(id=id),
-            data=data
+            data=data,
+            files=files,
         )
 
     def retrieve_profile(self, id):

--- a/tests/test_company.py
+++ b/tests/test_company.py
@@ -1,8 +1,9 @@
+from io import StringIO
+import tempfile
 from unittest import TestCase
 
-from tests import stub_request
-
 from exportdirectory.company import CompanyAPIClient
+from tests import stub_request
 
 
 class CompanyAPIClientTest(TestCase):
@@ -13,10 +14,33 @@ class CompanyAPIClientTest(TestCase):
         )
 
     @stub_request('https://example.com/company/1/', 'patch')
-    def test_update_profile(self, stub):
+    def test_update_profile_handles_data(self, stub):
         data = {'key': 'value'}
         self.client.update_profile(id=1, data=data)
-        assert stub.request_history[0].json() == data
+        request = stub.request_history[0]
+        assert request.json() == data
+
+    @stub_request('https://example.com/company/1/', 'patch')
+    def test_update_profile_handles_files(self, stub):
+        handle, logo_path = tempfile.mkstemp()
+        data = {
+            'logo': open(logo_path, 'rb'),
+        }
+        self.client.update_profile(id=1, data=data)
+        request = stub.request_history[0]
+
+    @stub_request('https://example.com/company/1/', 'patch')
+    def test_update_profile_handles_files_and_data(self, stub):
+        handle, logo_path = tempfile.mkstemp()
+        data = {
+            'logo': StringIO('hello'),
+            'key': 'value',
+        }
+        self.client.update_profile(id=1, data=data)
+        request = stub.request_history[0]
+        assert 'Content-Disposition: form-data;' in request.text
+        assert 'name="key"\r\n\r\nvalue\r\n' in request.text
+        assert 'filename="logo"\r\n\r\nhello\r\n' in request.text
 
     @stub_request('https://example.com/company/1/', 'get')
     def test_retrieve_profile(self, stub):

--- a/tests/test_company.py
+++ b/tests/test_company.py
@@ -24,10 +24,12 @@ class CompanyAPIClientTest(TestCase):
     def test_update_profile_handles_files(self, stub):
         handle, logo_path = tempfile.mkstemp()
         data = {
-            'logo': open(logo_path, 'rb'),
+            'logo': StringIO('hello'),
         }
         self.client.update_profile(id=1, data=data)
         request = stub.request_history[0]
+        assert 'Content-Disposition: form-data;' in request.text
+        assert 'filename="logo"\r\n\r\nhello\r\n' in request.text
 
     @stub_request('https://example.com/company/1/', 'patch')
     def test_update_profile_handles_files_and_data(self, stub):


### PR DESCRIPTION
[this task](https://uktrade.atlassian.net/browse/ED-188)

We can now simply pass the `logo` file to the api client and it will upload the file alongside the rest of the form data.