### PR TITLE
Fix sign_reqests

### DIFF
--- a/directory_api_client/base.py
+++ b/directory_api_client/base.py
@@ -95,8 +95,8 @@ class BaseAPIClient:
                 )
             )
 
-    def sign_request(self, api_key, url, prepared_request):
-        url = urlparse.urlsplit(url)
+    def sign_request(self, api_key, prepared_request):
+        url = urlparse.urlsplit(prepared_request.path_url)
         path = bytes(url.path, "utf-8")
 
         if url.query:
@@ -121,7 +121,6 @@ class BaseAPIClient:
 
         signed_request = self.sign_request(
             api_key=api_key,
-            url=url,
             prepared_request=prepared_request,
         )
         return requests.Session().send(signed_request)

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -59,7 +59,6 @@ class BaseAPIClientTest(TestCase):
 
         self.client.sign_request(
             api_key='test',
-            url=url,
             prepared_request=prepared_request,
         ),
 


### PR DESCRIPTION
`url` does not contain the queysering, but `prepared_request.path_url` does. The sibling function in api's alice permission class expects the querystring to be there