### PR TITLE
supplier.retrieve_profile now expects sso_id rather than sso_session_id

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,10 @@ jobs:
             python3 -m venv .venv
             . .venv/bin/activate
             make test_requirements
-            make test
+            make flake8
+            make pytest
+            codecov
+
   publish_to_pypi:
     docker:
       - image: circleci/python:3.6.6

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [19.0.0](https://pypi.org/project/directory-api-client/19.0.0/) (2019-09-09)
+[Full Changelog](https://github.com/uktrade/directory-api-client/pull/101/files)
+
+## Breaking changes
+- `supplier.retrieve_profile` now expects sso_id rather than sso_session_id
+
 
 ## [18.0.0](https://pypi.org/project/directory-api-client/18.0.0/) (2019-09-03)
 [Full Changelog](https://github.com/uktrade/directory-api-client/pull/99/files)

--- a/directory_api_client/supplier.py
+++ b/directory_api_client/supplier.py
@@ -2,11 +2,12 @@ from directory_client_core.authentication import SessionSSOAuthenticator
 from directory_api_client.base import AbstractAPIClient
 
 
-url_supplier = '/supplier/'
 url_unsubscribe = '/supplier/unsubscribe/'
+url_supplier_update = '/supplier/'
 url_csv_dump = '/supplier/csv-dump/'
 url_disconnect_from_company = '/supplier/company/disconnect/'
 url_supplier_sso_ids = '/external/supplier-sso/'
+url_supplier_detail = '/supplier/{sso_id}/'
 
 
 class SupplierAPIClient(AbstractAPIClient):
@@ -14,10 +15,10 @@ class SupplierAPIClient(AbstractAPIClient):
     authenticator = SessionSSOAuthenticator
 
     def profile_update(self, sso_session_id, data):
-        return self.patch(url=url_supplier, data=data, authenticator=self.authenticator(sso_session_id))
+        return self.patch(url=url_supplier_update, data=data, authenticator=self.authenticator(sso_session_id))
 
-    def retrieve_profile(self, sso_session_id):
-        return self.get(url=url_supplier, authenticator=self.authenticator(sso_session_id))
+    def retrieve_profile(self, sso_id):
+        return self.get(url=url_supplier_detail.format(sso_id=sso_id), use_fallback_cache=True)
 
     def unsubscribe(self, sso_session_id):
         return self.post(url=url_unsubscribe, authenticator=self.authenticator(sso_session_id))

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-build: test_requirements test
+ARGUMENTS = $(filter-out $@,$(MAKECMDGOALS))
 
 clean:
 	-find . -type f -name "*.pyc" -delete
@@ -11,25 +11,11 @@ flake8:
 	flake8 . --exclude=.venv --max-line-length=120
 
 pytest:
-	pytest . --cov=. $(pytest_args) -v
-
-CODECOV := \
-	if [ "$$CODECOV_REPO_TOKEN" != "" ]; then \
-	   codecov --token=$$CODECOV_REPO_TOKEN ;\
-	fi
-
-test: flake8 pytest
-	$(CODECOV)
-
-integration_tests:
-	cd $(mktemp -d) && \
-	git clone https://github.com/uktrade/directory-tests && \
-	cd directory-tests && \
-	make docker_integration_tests
+	pytest $(ARGUMENTS) --cov=. -v
 
 publish:
 	rm -rf build dist; \
 	python setup.py bdist_wheel; \
 	twine upload --username $$DIRECTORY_PYPI_USERNAME --password $$DIRECTORY_PYPI_PASSWORD dist/*
 
-.PHONY: build clean test_requirements flake8 pytest test publish
+.PHONY: clean test_requirements flake8 pytest publish

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='directory_api_client',
-    version='18.0.0',
+    version='19.0.0',
     url='https://github.com/uktrade/directory-api-client',
     license='MIT',
     author='Department for International Trade',

--- a/tests/test_supplier.py
+++ b/tests/test_supplier.py
@@ -26,10 +26,10 @@ def test_profile_update(client, requests_mock):
 
 
 def test_retrieve_profile(client, requests_mock):
-    url = 'https://example.com/supplier/'
+    url = 'https://example.com/supplier/123/'
     requests_mock.get(url)
 
-    client.retrieve_profile(sso_session_id=1)
+    client.retrieve_profile(123)
 
     assert requests_mock.last_request.url == url
 


### PR DESCRIPTION
 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 - [x] Fallback cache is not used on endpoints that lookup objects using sso session id
