### PR TITLE
GP2 1068: black and isort

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,6 +24,18 @@ jobs:
             . venv/bin/activate
             pip install flake8
             flake8
+  black:
+    docker:
+      - image: circleci/python:3.6.6
+    steps:
+      - checkout
+      - run:
+          name: Run Black in check mode
+          command: |
+            python3 -m venv .venv
+            . .venv/bin/activate
+            pip install black
+            black ./ --check           
 
   publish_to_pypi:
     docker:
@@ -42,11 +54,13 @@ workflows:
   test_and_publish_to_pypi:
     jobs:
       - flake8
+      - black
       - test
       - publish_to_pypi:
           requires:
             - test
             - flake8
+            - black
           filters:
             branches:
               only: master

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,8 +1,6 @@
 engines:
   radon:
     enabled: true
-  pep8:
-    enabled: true
   fixme:
     enabled: true
   duplication:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,39 @@
+repos:
+    - repo: https://github.com/psf/black
+      rev: 20.8b1
+      hooks:
+          - id: black
+          # Config for black lives in pyproject.toml
+    - repo: https://github.com/asottile/blacken-docs
+      rev: v1.6.0
+      hooks:
+          - id: blacken-docs
+            additional_dependencies: [black==20.8b1]
+    - repo: https://github.com/PyCQA/isort
+      rev: 5.6.4
+      hooks:
+          - id: isort
+    - repo: https://gitlab.com/pycqa/flake8
+      rev: 3.8.4
+      hooks:
+          - id: flake8
+    - repo: https://github.com/pre-commit/pre-commit-hooks
+      rev: v3.3.0
+      hooks:
+          - id: trailing-whitespace
+            args: ["--markdown-linebreak-ext=md,markdown"]
+          - id: end-of-file-fixer
+          - id: check-yaml
+          - id: check-added-large-files
+          # - id: fix-encoding-pragma
+          - id: check-ast
+          - id: check-byte-order-marker
+          - id: check-merge-conflict
+          - id: debug-statements
+          - id: detect-private-key
+# -   repo: https://github.com/pre-commit/pygrep-hooks
+#     rev: v1.7.0
+#     hooks:
+#     -   id: python-use-type-annotations
+#     -   id: python-no-eval
+#     -   id: python-no-log-warn

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+## [22.9.1](https://pypi.org/project/directory-api-client/22.9.0/) (2020-12-08)
+* GP2-1068 - adopt Black auto-formatting + provide optional pre-commit config
 
 ## [22.9.0](https://pypi.org/project/directory-api-client/22.9.0/) (2020-11-30)
 [Full Changelog](https://github.com/uktrade/directory-api-client/pull/128/files)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [22.9.1](https://pypi.org/project/directory-api-client/22.9.0/) (2020-12-08)
+## [22.9.1](https://pypi.org/project/directory-api-client/22.9.1/) (2020-12-10)
 * GP2-1068 - adopt Black auto-formatting + provide optional pre-commit config
 
 ## [22.9.0](https://pypi.org/project/directory-api-client/22.9.0/) (2020-11-30)

--- a/README.md
+++ b/README.md
@@ -10,26 +10,24 @@
 
 ---
 
-
 ## Installation
 
     $ pip install directory-api-client
 
-
 The api client expects the following settings:
 
-| Setting                                    | Notes                                                       |
-| ------------------------------------------ | ----------------------------------------------------------- |
-| DIRECTORY_API_CLIENT_BASE_URL              |                                                             |
-| DIRECTORY_API_CLIENT_API_KEY               | Unique to client. Retrieved during the on-boarding process. |
-| DIRECTORY_API_CLIENT_SENDER_ID             | Unique to client. Retrieved during the on-boarding process. |
-| DIRECTORY_API_CLIENT_DEFAULT_TIMEOUT       |                                                             |
+| Setting                              | Notes                                                       |
+| ------------------------------------ | ----------------------------------------------------------- |
+| DIRECTORY_API_CLIENT_BASE_URL        |                                                             |
+| DIRECTORY_API_CLIENT_API_KEY         | Unique to client. Retrieved during the on-boarding process. |
+| DIRECTORY_API_CLIENT_SENDER_ID       | Unique to client. Retrieved during the on-boarding process. |
+| DIRECTORY_API_CLIENT_DEFAULT_TIMEOUT |                                                             |
 
 The following [directory client core settings](https://github.com/uktrade/directory-client-core) also apply to directory cms client:
 
 | Setting                                            | Notes                                                 |
-| ---------------------------------------------------| ------------------------------------------------------|
-| DIRECTORY_CLIENT_CORE_CACHE_EXPIRE_SECONDS         | Duration to store the retrieved content in the cache. |    |
+| -------------------------------------------------- | ----------------------------------------------------- |
+| DIRECTORY_CLIENT_CORE_CACHE_EXPIRE_SECONDS         | Duration to store the retrieved content in the cache. |  |
 | DIRECTORY_CLIENT_CORE_CACHE_LOG_THROTTLING_SECONDS | Duration to throttle log events for a given url for.  |
 
 And the caching expects the following key in CACHES setting: `api_fallback`
@@ -49,39 +47,37 @@ $ [create virtual environment and activate]
 $ make test_requirements
 ```
 
+Use `make checks` to validate the codebase with `black` and `isort`, in dry-run mode
+Use `make autoformat` to run `black` and `isort` in file-updating mode
+
 ## Fallback cache
+
 Where feasible the response is cached to the client's fallback cache. This allows retrieval later if API returns non successful response or times out.
 
 When enabling the fallback cache on a handler make sure that the request's querystring or url path are unique per user, otherwise the User B's details could be leaked User A.
 
 For example, `api_client.company.profile_retrieve` looks up the company for the authenticated user. The authentication header is not used when generating the cache key for the response. This means for that endpoint the querystring and url are the same for all users, so the cache key would therefore also be the same for all users. This means if API was down then all users would see the company details for the last user to successfully retrieve their company.
 
-
 ## Publish to PyPI
 
 The package should be published to PyPI on merge to master. If you need to do it locally then get the credentials from rattic and add the environment variables to your host machine:
 
-| Setting                     |
-| --------------------------- |
-| DIRECTORY_PYPI_USERNAME     |
-| DIRECTORY_PYPI_PASSWORD     |
+| Setting                 |
+| ----------------------- |
+| DIRECTORY_PYPI_USERNAME |
+| DIRECTORY_PYPI_PASSWORD |
 
 Then run the following command:
 
     $ make publish
 
-
 [code-climate-image]: https://codeclimate.com/github/uktrade/directory-api-client/badges/issue_count.svg
 [code-climate]: https://codeclimate.com/github/uktrade/directory-api-client
-
 [circle-ci-image]: https://circleci.com/gh/uktrade/directory-api-client/tree/master.svg?style=svg
 [circle-ci]: https://circleci.com/gh/uktrade/directory-api-client/tree/master
-
 [codecov-image]: https://codecov.io/gh/uktrade/directory-api-client/branch/master/graph/badge.svg
 [codecov]: https://codecov.io/gh/uktrade/directory-api-client
-
 [pypi-image]: https://badge.fury.io/py/directory-api-client.svg
 [pypi]: https://badge.fury.io/py/directory-api-client
-
 [semver-image]: https://img.shields.io/badge/Versioning%20strategy-SemVer-5FBB1C.svg
 [semver]: https://semver.org

--- a/directory_api_client/base.py
+++ b/directory_api_client/base.py
@@ -1,8 +1,6 @@
-import pkg_resources
-
 import directory_client_core.base
+import pkg_resources
 from directory_client_core.helpers import fallback
-
 from django.core.cache import caches
 
 

--- a/directory_api_client/buyer.py
+++ b/directory_api_client/buyer.py
@@ -1,12 +1,10 @@
 from directory_api_client.base import AbstractAPIClient
 
-
 url_save = '/buyer/'
 url_csv_dump = '/buyer/csv-dump/'
 
 
 class BuyerAPIClient(AbstractAPIClient):
-
     def send_form(self, form_data):
         return self.post(url_save, data=form_data)
 

--- a/directory_api_client/client.py
+++ b/directory_api_client/client.py
@@ -3,19 +3,18 @@ from django.conf import settings
 from directory_api_client.base import AbstractAPIClient
 from directory_api_client.buyer import BuyerAPIClient
 from directory_api_client.company import CompanyAPIClient
+from directory_api_client.dataservices import DataServicesAPIClient
 from directory_api_client.enrolment import EnrolmentAPIClient
-from directory_api_client.supplier import SupplierAPIClient
-from directory_api_client.notifications import NotificationsAPIClient
 from directory_api_client.exporting import ExportingAPIClient
 from directory_api_client.exportplan import ExportPlanAPIClient
+from directory_api_client.notifications import NotificationsAPIClient
 from directory_api_client.personalisation import PersonalisationAPIClient
-from directory_api_client.dataservices import DataServicesAPIClient
+from directory_api_client.supplier import SupplierAPIClient
 
 url_ping = '/healthcheck/ping/'
 
 
 class DirectoryAPIClient(AbstractAPIClient):
-
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.enrolment = EnrolmentAPIClient(*args, **kwargs)

--- a/directory_api_client/company.py
+++ b/directory_api_client/company.py
@@ -2,7 +2,6 @@ from directory_client_core.authentication import SessionSSOAuthenticator
 
 from directory_api_client.base import AbstractAPIClient
 
-
 url_profile = '/supplier/company/'
 url_case_study_detail = '/supplier/company/case-study/{id}/'
 url_case_study_published_detail = '/public/case-study/{id}/'
@@ -45,7 +44,10 @@ class CompanyAPIClient(AbstractAPIClient):
         return self.get(url=url_profile, authenticator=self.authenticator(sso_session_id))
 
     def published_profile_retrieve(self, number):
-        return self.get(url=url_published_profile_detail.format(number=number), use_fallback_cache=True,)
+        return self.get(
+            url=url_published_profile_detail.format(number=number),
+            use_fallback_cache=True,
+        )
 
     def validate_company_number(self, number):
         return self.get(url=url_validate_company_number, params={'number': number})
@@ -76,8 +78,7 @@ class CompanyAPIClient(AbstractAPIClient):
 
     def case_study_delete(self, sso_session_id, case_study_id):
         return self.delete(
-            url=url_case_study_detail.format(id=case_study_id),
-            authenticator=self.authenticator(sso_session_id)
+            url=url_case_study_detail.format(id=case_study_id), authenticator=self.authenticator(sso_session_id)
         )
 
     def case_study_retrieve(self, sso_session_id, case_study_id):
@@ -105,7 +106,10 @@ class CompanyAPIClient(AbstractAPIClient):
         )
 
     def verify_identity_request(self, sso_session_id):
-        return self.post(url=url_verify_with_identity_request, authenticator=self.authenticator(sso_session_id),)
+        return self.post(
+            url=url_verify_with_identity_request,
+            authenticator=self.authenticator(sso_session_id),
+        )
 
     def search_find_a_supplier(self, **kwargs):
         return self.get(url=url_search_find_a_supplier, params=kwargs, use_fallback_cache=True)
@@ -136,7 +140,8 @@ class CompanyAPIClient(AbstractAPIClient):
     def collaborator_invite_retrieve(self, invite_key):
         """Retrieve the details of a collaboration invite"""
         return self.get(
-            url=url_collaborator_invite_detail.format(invite_key=invite_key), use_fallback_cache=True,
+            url=url_collaborator_invite_detail.format(invite_key=invite_key),
+            use_fallback_cache=True,
         )
 
     def collaborator_invite_list(self, sso_session_id):

--- a/directory_api_client/dataservices.py
+++ b/directory_api_client/dataservices.py
@@ -14,12 +14,8 @@ url_suggested_countries = '/dataservices/suggested-countries/'
 
 
 class DataServicesAPIClient(AbstractAPIClient):
-
     def get_corruption_perceptions_index(self, country_code):
-        return self.get(
-            url=url_corruption_perceptions_index.format(country_code=country_code),
-            use_fallback_cache=True
-        )
+        return self.get(url=url_corruption_perceptions_index.format(country_code=country_code), use_fallback_cache=True)
 
     def get_ease_of_doing_business(self, country_code):
         return self.get(
@@ -28,59 +24,39 @@ class DataServicesAPIClient(AbstractAPIClient):
         )
 
     def get_last_year_import_data(self, commodity_code, country):
-        return self.get(
-            url=url_last_year_import_data,
-            params={'commodity_code': commodity_code, 'country': country}
-        )
+        return self.get(url=url_last_year_import_data, params={'commodity_code': commodity_code, 'country': country})
 
     def get_historical_import_data(self, commodity_code, country):
-        return self.get(
-            url=url_historical_import_data,
-            params={'commodity_code': commodity_code, 'country': country}
-        )
+        return self.get(url=url_historical_import_data, params={'commodity_code': commodity_code, 'country': country})
 
     def get_world_economic_outlook_data(self, country_code):
-        return self.get(
-            url=url_world_economic_outlook_data.format(country_code=country_code),
-            use_fallback_cache=True
-        )
+        return self.get(url=url_world_economic_outlook_data.format(country_code=country_code), use_fallback_cache=True)
 
     def get_country_data(self, country):
-        return self.get(
-            url=url_country_data_data.format(country=country),
-            use_fallback_cache=True
-        )
+        return self.get(url=url_country_data_data.format(country=country), use_fallback_cache=True)
 
     def get_cia_world_factbook_data(self, country, data_key):
         return self.get(
-            url=url_cia_world_factbook_data,
-            params={'country': country, 'data_key': data_key},
-            use_fallback_cache=True
+            url=url_cia_world_factbook_data, params={'country': country, 'data_key': data_key}, use_fallback_cache=True
         )
 
     def get_population_data(self, country, target_ages):
         return self.get(
-            url=url_population_data,
-            params={'country': country, 'target_ages': target_ages},
-            use_fallback_cache=True
+            url=url_population_data, params={'country': country, 'target_ages': target_ages}, use_fallback_cache=True
         )
 
     def get_population_data_by_country(self, countries: list):
-        return self.get(
-            url=url_population_data_by_country,
-            params={'countries': countries},
-            use_fallback_cache=True
-        )
+        return self.get(url=url_population_data_by_country, params={'countries': countries}, use_fallback_cache=True)
 
     def get_last_year_import_data_from_uk(self, commodity_code, countries):
         return self.get(
-            url=url_last_year_import_data_from_uk,
-            params={'commodity_code': commodity_code, 'countries': countries}
+            url=url_last_year_import_data_from_uk, params={'commodity_code': commodity_code, 'countries': countries}
         )
 
-    def suggested_countries_by_hs_code(
-        self, hs_code
-    ):
+    def suggested_countries_by_hs_code(self, hs_code):
         return self.get(
-            url=url_suggested_countries, params={'hs_code': hs_code, }
+            url=url_suggested_countries,
+            params={
+                'hs_code': hs_code,
+            },
         )

--- a/directory_api_client/enrolment.py
+++ b/directory_api_client/enrolment.py
@@ -2,14 +2,12 @@ from directory_client_core.authentication import SessionSSOAuthenticator
 
 from directory_api_client.base import AbstractAPIClient
 
-
 url_enrolment = '/enrolment/'
 url_preverified = '/enrolment/preverified-company/{key}/'
 url_preverified_claim = '/enrolment/preverified-company/{key}/claim/'
 
 
 class EnrolmentAPIClient(AbstractAPIClient):
-
     def send_form(self, form_data):
         return self.post(url=url_enrolment, data=form_data)
 

--- a/directory_api_client/exporting.py
+++ b/directory_api_client/exporting.py
@@ -1,10 +1,11 @@
 from directory_api_client.base import AbstractAPIClient
 
-
 url_lookup_by_postcode = '/exporting/offices/{postcode}/'
 
 
 class ExportingAPIClient(AbstractAPIClient):
-
     def lookup_regional_offices_by_postcode(self, postcode):
-        return self.get(url=url_lookup_by_postcode.format(postcode=postcode), use_fallback_cache=True,)
+        return self.get(
+            url=url_lookup_by_postcode.format(postcode=postcode),
+            use_fallback_cache=True,
+        )

--- a/directory_api_client/exportplan.py
+++ b/directory_api_client/exportplan.py
@@ -1,6 +1,6 @@
 from directory_client_core.authentication import SessionSSOAuthenticator
-from directory_api_client.base import AbstractAPIClient
 
+from directory_api_client.base import AbstractAPIClient
 
 url_exportplan_create = '/exportplan/company-export-plan/'
 url_exportplan_update = '/exportplan/company-export-plan/{pk}/'
@@ -36,7 +36,7 @@ class ExportPlanAPIClient(AbstractAPIClient):
         return self.get(
             url=url_exportplan_detail.format(pk=id),
             use_fallback_cache=True,
-            authenticator=self.authenticator(sso_session_id)
+            authenticator=self.authenticator(sso_session_id),
         )
 
     def exportplan_create(self, sso_session_id, data):
@@ -49,27 +49,24 @@ class ExportPlanAPIClient(AbstractAPIClient):
         return self.patch(
             url=url_exportplan_objectives_update.format(pk=id),
             data=data,
-            authenticator=self.authenticator(sso_session_id)
+            authenticator=self.authenticator(sso_session_id),
         )
 
     def exportplan_objectives_delete(self, sso_session_id, id):
         return self.delete(
-            url=url_exportplan_objectives_update.format(pk=id),
-            authenticator=self.authenticator(sso_session_id)
+            url=url_exportplan_objectives_update.format(pk=id), authenticator=self.authenticator(sso_session_id)
         )
 
     def exportplan_objectives_detail(self, sso_session_id, id):
         return self.get(
             url=url_exportplan_objectives_detail.format(pk=id),
             use_fallback_cache=True,
-            authenticator=self.authenticator(sso_session_id)
+            authenticator=self.authenticator(sso_session_id),
         )
 
     def exportplan_objectives_create(self, sso_session_id, data):
         return self.post(
-            url=url_exportplan_objectives_create,
-            data=data,
-            authenticator=self.authenticator(sso_session_id)
+            url=url_exportplan_objectives_create, data=data, authenticator=self.authenticator(sso_session_id)
         )
 
     def exportplan_objectives_list(self, sso_session_id):
@@ -77,30 +74,23 @@ class ExportPlanAPIClient(AbstractAPIClient):
 
     def route_to_market_update(self, sso_session_id, id, data):
         return self.patch(
-            url=url_route_to_market_update.format(pk=id),
-            data=data,
-            authenticator=self.authenticator(sso_session_id)
+            url=url_route_to_market_update.format(pk=id), data=data, authenticator=self.authenticator(sso_session_id)
         )
 
     def route_to_market_delete(self, sso_session_id, id):
         return self.delete(
-            url=url_route_to_market_update.format(pk=id),
-            authenticator=self.authenticator(sso_session_id)
+            url=url_route_to_market_update.format(pk=id), authenticator=self.authenticator(sso_session_id)
         )
 
     def route_to_market_detail(self, sso_session_id, id):
         return self.get(
             url=url_route_to_market_detail.format(pk=id),
             use_fallback_cache=True,
-            authenticator=self.authenticator(sso_session_id)
+            authenticator=self.authenticator(sso_session_id),
         )
 
     def route_to_market_create(self, sso_session_id, data):
-        return self.post(
-            url=url_route_to_market_create,
-            data=data,
-            authenticator=self.authenticator(sso_session_id)
-        )
+        return self.post(url=url_route_to_market_create, data=data, authenticator=self.authenticator(sso_session_id))
 
     def route_to_market_list(self, sso_session_id):
         return self.get(url=url_route_to_market_list, authenticator=self.authenticator(sso_session_id))
@@ -109,27 +99,24 @@ class ExportPlanAPIClient(AbstractAPIClient):
         return self.patch(
             url=url_target_market_documents_update.format(pk=id),
             data=data,
-            authenticator=self.authenticator(sso_session_id)
+            authenticator=self.authenticator(sso_session_id),
         )
 
     def target_market_documents_delete(self, sso_session_id, id):
         return self.delete(
-            url=url_target_market_documents_update.format(pk=id),
-            authenticator=self.authenticator(sso_session_id)
+            url=url_target_market_documents_update.format(pk=id), authenticator=self.authenticator(sso_session_id)
         )
 
     def target_market_documents_detail(self, sso_session_id, id):
         return self.get(
             url=url_target_market_documents_detail.format(pk=id),
             use_fallback_cache=True,
-            authenticator=self.authenticator(sso_session_id)
+            authenticator=self.authenticator(sso_session_id),
         )
 
     def target_market_documents_create(self, sso_session_id, data):
         return self.post(
-            url=url_target_market_documents_create,
-            data=data,
-            authenticator=self.authenticator(sso_session_id)
+            url=url_target_market_documents_create, data=data, authenticator=self.authenticator(sso_session_id)
         )
 
     def target_market_documents_list(self, sso_session_id):

--- a/directory_api_client/notifications.py
+++ b/directory_api_client/notifications.py
@@ -1,10 +1,8 @@
 from directory_api_client.base import AbstractAPIClient
 
-
 url_unsubscribe = '/notifications/anonymous-unsubscribe/'
 
 
 class NotificationsAPIClient(AbstractAPIClient):
-
     def anonymous_unsubscribe(self, signed_email_address):
         return self.post(url=url_unsubscribe, data={'email': signed_email_address})

--- a/directory_api_client/personalisation.py
+++ b/directory_api_client/personalisation.py
@@ -1,4 +1,5 @@
 from directory_client_core.authentication import SessionSSOAuthenticator
+
 from directory_api_client.base import AbstractAPIClient
 
 url_user_location_create = '/personalisation/user-location/'
@@ -11,29 +12,23 @@ class PersonalisationAPIClient(AbstractAPIClient):
     authenticator = SessionSSOAuthenticator
 
     def user_location_create(self, sso_session_id, data):
-        return self.post(
-            url=url_user_location_create,
-            data=data,
-            authenticator=self.authenticator(sso_session_id)
-        )
+        return self.post(url=url_user_location_create, data=data, authenticator=self.authenticator(sso_session_id))
 
     def events_by_location_list(self, sso_session_id, lat='', lng=''):
-        return self.get(url=url_events, params={
-          'lat': lat,
-          'lng': lng
-        }, authenticator=self.authenticator(sso_session_id))
-
-    def export_opportunities_by_relevance_list(
-        self, sso_session_id, search_term=''
-    ):
         return self.get(
-            url=url_export_opportunities.format(search_term),
-            authenticator=self.authenticator(sso_session_id)
+            url=url_events, params={'lat': lat, 'lng': lng}, authenticator=self.authenticator(sso_session_id)
         )
 
-    def recommended_countries_by_sector(
-        self, sso_session_id, sector=''
-    ):
+    def export_opportunities_by_relevance_list(self, sso_session_id, search_term=''):
         return self.get(
-            url=url_recommended_countries, params={'sector': sector, }, authenticator=self.authenticator(sso_session_id)
+            url=url_export_opportunities.format(search_term), authenticator=self.authenticator(sso_session_id)
+        )
+
+    def recommended_countries_by_sector(self, sso_session_id, sector=''):
+        return self.get(
+            url=url_recommended_countries,
+            params={
+                'sector': sector,
+            },
+            authenticator=self.authenticator(sso_session_id),
         )

--- a/directory_api_client/supplier.py
+++ b/directory_api_client/supplier.py
@@ -1,6 +1,6 @@
 from directory_client_core.authentication import SessionSSOAuthenticator
-from directory_api_client.base import AbstractAPIClient
 
+from directory_api_client.base import AbstractAPIClient
 
 url_unsubscribe = '/supplier/unsubscribe/'
 url_supplier_update = '/supplier/'

--- a/directory_api_client/testapiclient.py
+++ b/directory_api_client/testapiclient.py
@@ -1,12 +1,10 @@
 from directory_api_client.base import AbstractAPIClient
 
-
 url_company_by_ch_id = '/testapi/company/{companies_house_number}/'
 url_published_companies = '/testapi/companies/published/'
 
 
 class DirectoryTestAPIClient(AbstractAPIClient):
-
     def get_company_by_ch_id(self, ch_id, authenticator=None):
         return self.get(
             url=url_company_by_ch_id.format(companies_house_number=ch_id),
@@ -19,9 +17,7 @@ class DirectoryTestAPIClient(AbstractAPIClient):
             authenticator=authenticator,
         )
 
-    def get_published_companies(
-            self, *, limit=None, minimal_number_of_sectors=None, authenticator=None
-    ):
+    def get_published_companies(self, *, limit=None, minimal_number_of_sectors=None, authenticator=None):
         params = {}
         if limit:
             params['limit'] = limit

--- a/makefile
+++ b/makefile
@@ -15,4 +15,14 @@ publish:
 	python setup.py bdist_wheel; \
 	twine upload --username $$DIRECTORY_PYPI_USERNAME --password $$DIRECTORY_PYPI_PASSWORD dist/*
 
-.PHONY: clean test_requirements flake8 pytest publish
+# configuration for black and isort is in pyproject.toml
+autoformat:
+	isort $(PWD)
+	black $(PWD)
+
+checks:
+	isort $(PWD) --check
+	black $(PWD) --check --verbose
+	flake8 .
+
+.PHONY: clean test_requirements flake8 pytest publish autoformat checks

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,30 @@
+[tool.black]
+line-length = 120
+skip-string-normalization = true
+target-version = ['py36']
+include = '\.pyi?$'
+exclude = '''
+(
+  /(
+      \.eggs         # exclude a few common directories in the
+    | \.git          # root of the project
+    | \.circleci
+    | \.pytest_cache
+    | \.venv
+    | \.vscode
+    | build
+    | directory_api_client.egg-info
+    | dist
+    | venv
+  )/
+  | manage.py       # also separately exclude a file in the root of the project
+)
+'''
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+ensure_newline_before_comments = true
+line_length = 120

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,8 @@
-from setuptools import setup, find_packages
-
+from setuptools import find_packages, setup
 
 setup(
     name='directory_api_client',
-    version='22.9.0',
+    version='22.9.1',
     url='https://github.com/uktrade/directory-api-client',
     license='MIT',
     author='Department for International Trade',
@@ -20,13 +19,17 @@ setup(
     extras_require={
         'test': [
             'codecov==2.1.7',
-            'flake8==3.7.9',
             'pytest-cov==2.8.1',
             'pytest==5.3.5',
             'requests_mock==1.7.0',
             'setuptools>=45.2.0,<50.0.0',
             'twine>=3.1.1,<4.0.0',
             'wheel>=0.34.2,<1.0.0',
+            'black==20.8b1',
+            'blacken-docs==1.6.0',
+            'isort==5.6.4',
+            'flake8==3.8.4',
+            'pre-commit-hooks==3.3.0',
         ]
     },
     classifiers=[
@@ -44,5 +47,5 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: Implementation :: PyPy',
         'Topic :: Software Development :: Libraries :: Python Modules',
-    ]
+    ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,6 @@
 def pytest_configure():
     from django.conf import settings
+
     settings.configure(
         URLS_EXCLUDED_FROM_SIGNATURE_CHECK=[],
         DIRECTORY_API_CLIENT_BASE_URL='https://api.com',
@@ -12,5 +13,5 @@ def pytest_configure():
                 'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
                 'LOCATION': 'unique-snowflake',
             }
-        }
+        },
     )

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -4,9 +4,9 @@ from directory_api_client.buyer import BuyerAPIClient
 from directory_api_client.client import DirectoryAPIClient
 from directory_api_client.company import CompanyAPIClient
 from directory_api_client.enrolment import EnrolmentAPIClient
-from directory_api_client.supplier import SupplierAPIClient
 from directory_api_client.exporting import ExportingAPIClient
 from directory_api_client.personalisation import PersonalisationAPIClient
+from directory_api_client.supplier import SupplierAPIClient
 
 
 @pytest.fixture

--- a/tests/test_company.py
+++ b/tests/test_company.py
@@ -303,10 +303,15 @@ def test_collaborator_invite_accept(requests_mock, client):
     url = 'https://example.com/supplier/company/collaborator-invite/123/'
     requests_mock.patch(url)
 
-    client.collaborator_invite_accept(sso_session_id=2, invite_key='123',)
+    client.collaborator_invite_accept(
+        sso_session_id=2,
+        invite_key='123',
+    )
 
     assert requests_mock.last_request.url == url
-    assert requests_mock.last_request.json() == {'accepted': True, }
+    assert requests_mock.last_request.json() == {
+        'accepted': True,
+    }
     assert requests_mock.last_request.headers['Authorization'] == 'SSO_SESSION_ID 2'
 
 

--- a/tests/test_testapiclient.py
+++ b/tests/test_testapiclient.py
@@ -1,8 +1,8 @@
 import base64
 
-from directory_api_client.testapiclient import DirectoryTestAPIClient
-
 import pytest
+
+from directory_api_client.testapiclient import DirectoryTestAPIClient
 
 
 @pytest.fixture
@@ -174,9 +174,7 @@ def test_get_published_companies_with_one_filter(client, requests_mock):
     assert 'minimal_number_of_sectors=5' in requests_mock.last_request.url
 
 
-def test_get_company_by_ch_id_with_authenticator(
-        client, requests_mock, basic_authenticator
-):
+def test_get_company_by_ch_id_with_authenticator(client, requests_mock, basic_authenticator):
     url = 'http://test.uk/testapi/company/12345678/'
     requests_mock.get(url)
     client.get_company_by_ch_id(ch_id='12345678', authenticator=basic_authenticator)
@@ -184,9 +182,7 @@ def test_get_company_by_ch_id_with_authenticator(
     assert requests_mock.last_request.headers['Authorization'].startswith('Basic ')
 
 
-def test_delete_company_by_ch_id_with_authenticator(
-        client, requests_mock, basic_authenticator
-):
+def test_delete_company_by_ch_id_with_authenticator(client, requests_mock, basic_authenticator):
     url = 'http://test.uk/testapi/company/ch_ID_00/'
     requests_mock.delete(url)
 
@@ -196,7 +192,7 @@ def test_delete_company_by_ch_id_with_authenticator(
 
 
 def test_get_published_companies_without_optional_parameters_with_authenticator(
-        client, requests_mock, basic_authenticator
+    client, requests_mock, basic_authenticator
 ):
     url = 'http://test.uk/testapi/companies/published/'
     requests_mock.get(url)


### PR DESCRIPTION
GP2-1068: Set up black + isort + support use of pre-commit

* add Black and related deps to test requirements
* add minimal Black config in pyproject.toml which will be used by default
* config for isort so that it doesn't conflict with Black
* add makefile commands to use black in check or write mode (`make checks` or `make autoformat`)
* update CI config to run `black --check` in CI, too
* add .pre-commit-config.yaml for pre-commit (see pre-commit.com)
* DISABLE pep8 checks in codeclimate - we already have flake8 and now we have black running in github CI too

* UPDATE VERSION to 22.9.1

* Apply Black and isort to the entire codebase - this brings it in to line with Black, while also ensures that if you use pre-commit (which also runs isort) we starting from a clean slate.



