### PR TITLE
GP2-1724 remove redundant contrade endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [22.16.0](https://pypi.org/project/directory-api-client/22.15.0/) (2021-03-12)
+* GP2-1724 - remove redundant comtrade endpoints
+
 ## [22.15.0](https://pypi.org/project/directory-api-client/22.15.0/) (2021-02-26)
 * GP2-1398 - added multiple country endpoints for import data and country data
 

--- a/directory_api_client/dataservices.py
+++ b/directory_api_client/dataservices.py
@@ -2,15 +2,12 @@ from directory_api_client.base import AbstractAPIClient
 
 url_corruption_perceptions_index = 'dataservices/corruption-perceptions-index/{country_code}/'
 url_ease_of_doing_business = 'dataservices/easeofdoingbusiness/{country_code}/'
-url_historical_import_data = 'dataservices/historicalimportdata/'
-url_world_economic_outlook_data = 'dataservices/world-economic-outlook/{country_code}/'
 url_country_data = 'dataservices/country-data/{country}/'
 url_country_data_by_country = 'dataservices/country-data/'
 url_cia_world_factbook_data = 'dataservices/cia-factbook-data/'
 url_population_data = 'dataservices/population-data/'
 url_population_data_by_country = 'dataservices/population-data-by-country/'
 url_society_data_by_country = 'dataservices/society-data-by-country/'
-url_last_year_import_data = 'dataservices/lastyearimportdata/'
 url_last_year_import_data_by_country = 'dataservices/lastyearimportdatabycountry/'
 url_suggested_countries = '/dataservices/suggested-countries/'
 url_trading_blocs_by_country = '/dataservices/trading-blocs/'
@@ -25,15 +22,6 @@ class DataServicesAPIClient(AbstractAPIClient):
             url=url_ease_of_doing_business.format(country_code=country_code),
             use_fallback_cache=True,
         )
-
-    def get_last_year_import_data(self, commodity_code, country):
-        return self.get(url=url_last_year_import_data, params={'commodity_code': commodity_code, 'country': country})
-
-    def get_historical_import_data(self, commodity_code, country):
-        return self.get(url=url_historical_import_data, params={'commodity_code': commodity_code, 'country': country})
-
-    def get_world_economic_outlook_data(self, country_code):
-        return self.get(url=url_world_economic_outlook_data.format(country_code=country_code), use_fallback_cache=True)
 
     def get_country_data(self, country):
         return self.get(url=url_country_data.format(country=country), use_fallback_cache=True)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_api_client',
-    version='22.15.0',
+    version='22.16.0',
     url='https://github.com/uktrade/directory-api-client',
     license='MIT',
     author='Department for International Trade',

--- a/tests/test_dataservices.py
+++ b/tests/test_dataservices.py
@@ -29,30 +29,6 @@ def test_get_easeofdoingbusiness(client, requests_mock):
     assert requests_mock.last_request.url == url
 
 
-def test_get_lastyearimportdata(requests_mock, client):
-    url = 'https://example.com/dataservices/lastyearimportdata/?commodity_code=1234&country=China'
-    requests_mock.get(url)
-    client.get_last_year_import_data(commodity_code=1234, country='China')
-
-    assert requests_mock.last_request.url == url
-
-
-def test_get_historicalimportdata(requests_mock, client):
-    url = 'https://example.com/dataservices/historicalimportdata/?commodity_code=1234&country=China'
-    requests_mock.get(url)
-    client.get_historical_import_data(commodity_code=1234, country='China')
-
-    assert requests_mock.last_request.url == url
-
-
-def test_get_world_exconomic_outlook_data(client, requests_mock):
-    url = 'https://example.com/dataservices/world-economic-outlook/CHN/'
-    requests_mock.get(url)
-    client.get_world_economic_outlook_data(country_code='CHN')
-
-    assert requests_mock.last_request.url == url
-
-
 def test_get_country_data(client, requests_mock):
     url = 'https://example.com/dataservices/country-data/China/'
     requests_mock.get(url)


### PR DESCRIPTION
This PR just removes older comtrade endpoints and an economic outlook EP that are no longer used

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.

