### PR TITLE
v24.0.0 - Anonymous unsubscribe via token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,17 @@
 # Changelog
+
+## [24.0.0](https://pypi.org/project/directory-api-client/24.0.0/) (2021-09-16)
+- GP2-3343 - Anonymous unsubscribe via token - Breaking change
+
 ## [23.1.5](https://pypi.org/project/directory-api-client/23.1.5/) (2021-09-09)
-GP2-3341-fix-ep-caching
+- GP2-3341-fix-ep-caching
 
 ## [23.1.4](https://pypi.org/project/directory-api-client/23.1.4/) (2021-09-02)
 - No ticket - Test publish process
 
-# Changelog
 ## [23.1.3](https://pypi.org/project/directory-api-client/23.1.3/) (2021-09-01)
 - GP2-3275 - Export-plan-delete
 
-# Changelog
 ## [23.00.0](https://pypi.org/project/directory-api-client/23.00.0/) (2021-06-07)
 - GP2-3173 multi-Export-plan-list Breaking change
 

--- a/directory_api_client/notifications.py
+++ b/directory_api_client/notifications.py
@@ -4,5 +4,5 @@ url_unsubscribe = '/notifications/anonymous-unsubscribe/'
 
 
 class NotificationsAPIClient(AbstractAPIClient):
-    def anonymous_unsubscribe(self, signed_email_address):
-        return self.post(url=url_unsubscribe, data={'email': signed_email_address})
+    def anonymous_unsubscribe(self, uidb64, token):
+        return self.post(url=url_unsubscribe, data={'uidb64': uidb64, 'token': token})

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_api_client',
-    version='23.1.5',
+    version='24.0.0',
     url='https://github.com/uktrade/directory-api-client',
     license='MIT',
     author='Department for International Trade',

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -17,7 +17,7 @@ def test_anonymous_unsubscribe(client, requests_mock):
     url = 'https://e.com/notifications/anonymous-unsubscribe/'
     requests_mock.post(url)
 
-    client.anonymous_unsubscribe(signed_email_address='a@b.com:1234')
+    client.anonymous_unsubscribe(uidb64='aBcDe', token='1a2b3c')
 
     assert requests_mock.last_request.url == url
-    assert requests_mock.last_request.json() == {'email': 'a@b.com:1234'}
+    assert requests_mock.last_request.json() == {'uidb64': 'aBcDe', 'token': '1a2b3c'}


### PR DESCRIPTION
This PR changes a method signature for anonymous unsubscriptions to be handled with `uidb64` and `token` arguments - Breaking change

To do:

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.
 
