### PR TITLE
Enable requests to economic highlights endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [24.6.0](https://pypi.org/project/directory-api-client/24.6.0/) (2022-05-25)
+
+- GLS-360 - Data services economic highlights endpoint
+
 ## [24.5.1](https://pypi.org/project/directory-api-client/24.5.1/) (2022-05-25)
 
 - GLS-186 - Remove unused year parameter

--- a/directory_api_client/dataservices.py
+++ b/directory_api_client/dataservices.py
@@ -12,6 +12,7 @@ url_trade_highlights = '/dataservices/uk-trade-highlights/'
 url_commodity_exports_data_by_country = '/dataservices/commodity-exports-data-by-country/'
 url_top_five_services = '/dataservices/top-five-services/'
 url_top_five_goods = '/dataservices/top-five-goods/'
+url_economic_highlights = "/dataservices/economic-highlights/"
 
 
 class DataServicesAPIClient(AbstractAPIClient):
@@ -79,3 +80,6 @@ class DataServicesAPIClient(AbstractAPIClient):
 
     def get_top_five_goods_by_country(self, iso2):
         return self.get(url=url_top_five_goods, params={'iso2': iso2})
+
+    def get_economic_highlights_by_country(self, iso2):
+        return self.get(url=url_economic_highlights, params={"iso2": iso2})

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_api_client',
-    version='24.5.1',
+    version='24.6.0',
     url='https://github.com/uktrade/directory-api-client',
     license='MIT',
     author='Department for International Trade',

--- a/tests/test_dataservices.py
+++ b/tests/test_dataservices.py
@@ -112,3 +112,10 @@ def test_get_top_five_goods(requests_mock, client):
     client.get_top_five_goods_by_country(iso2='FR')
 
     assert requests_mock.last_request.url == f'{url}?iso2=FR'
+
+
+def test_get_economic_highlights(requests_mock, client):
+    url = 'https://example.com/dataservices/economic-highlights/'
+    requests_mock.get(url)
+    client.get_economic_highlights_by_country(iso2='FR')
+    assert requests_mock.last_request.url == f'{url}?iso2=FR'


### PR DESCRIPTION
This PR adds a handler for requests to the `dataservices/economic-highlights/` endpoint.

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.

 
