### PR TITLE
Enable requests to get survey details

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
     - repo: https://github.com/psf/black
-      rev: 20.8b1
+      rev: 22.10.0
       hooks:
           - id: black
           # Config for black lives in pyproject.toml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [26.1.0](https://pypi.org/project/directory-api-client/26.1.0/) (2022-10-20)
+
+- KLS-245 - Survey details endpoint
+
 ## [26.0.0](https://pypi.org/project/directory-api-client/26.0.0/) (2022-10-20)
 
 - KLS-97 - Data services UK's FTAs endpoint

--- a/directory_api_client/survey.py
+++ b/directory_api_client/survey.py
@@ -1,0 +1,8 @@
+from directory_api_client.base import AbstractAPIClient
+
+url_get_survey_details = 'survey/{pk}'
+
+
+class SurveyAPIClient(AbstractAPIClient):
+    def get_survey_details(self, id):
+        return self.get(url=url_get_survey_details.format(pk=id), use_fallback_cache=True)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setup(
             'setuptools>=45.2.0,<50.0.0',
             'twine>=3.1.1,<4.0.0',
             'wheel>=0.34.2,<1.0.0',
-            'black==20.8b1',
+            'black==22.10.0',
             'blacken-docs==1.6.0',
             'isort==5.6.4',
             'flake8==5.0.4',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_api_client',
-    version='26.0.0',
+    version='26.1.0',
     url='https://github.com/uktrade/directory-api-client',
     license='MIT',
     author='Department for International Trade',

--- a/tests/test_survey.py
+++ b/tests/test_survey.py
@@ -1,0 +1,20 @@
+import pytest
+
+from directory_api_client.survey import SurveyAPIClient
+
+
+@pytest.fixture
+def client():
+    return SurveyAPIClient(
+        base_url='https://example.com',
+        api_key='test',
+        sender_id='test',
+        timeout=5,
+    )
+
+
+def test_get_survey_details(requests_mock, client):
+    url = 'https://example.com/survey/123'
+    requests_mock.get(url)
+    client.get_survey_details(id='123')
+    assert requests_mock.last_request.url == url


### PR DESCRIPTION
This PR adds a new API client for surveys, including a method to get survey details from directory-api.

It also includes an upgrade to the `black` package which fixes an incompatibility issue when running black on the project.

 - [x] Change has a jira ticket that has the correct status.
 - [x] Changelog entry added.
 
