### PR TITLE
Bump Django version to 3.2.18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
+## [26.2.1](https://pypi.org/project/directory-api-client/26.2.1/) (2023-02-16)
+
+- KLS-400 - Upgrade vulnerable django version to Django 3.2.18
+
 ## [26.2.0](https://pypi.org/project/directory-api-client/26.2.0/) (2023-01-10)
+
 - Upgrade Wheel package to 0.38.1
 
 ## [26.1.0](https://pypi.org/project/directory-api-client/26.1.0/) (2022-12-07)

--- a/directory_api_client/base.py
+++ b/directory_api_client/base.py
@@ -5,7 +5,6 @@ from django.core.cache import caches
 
 
 class AbstractAPIClient(directory_client_core.base.AbstractAPIClient):
-
     version = pkg_resources.get_distribution(__package__).version
 
     @fallback(cache=caches['api_fallback'])

--- a/directory_api_client/company.py
+++ b/directory_api_client/company.py
@@ -26,7 +26,6 @@ url_company_delete_by_sso_id = '/supplier/company/{sso_id}/{request_key}/'
 
 
 class CompanyAPIClient(AbstractAPIClient):
-
     authenticator = SessionSSOAuthenticator
 
     def profile_update(self, sso_session_id, data):

--- a/directory_api_client/supplier.py
+++ b/directory_api_client/supplier.py
@@ -11,7 +11,6 @@ url_supplier_detail = '/supplier/{sso_id}/'
 
 
 class SupplierAPIClient(AbstractAPIClient):
-
     authenticator = SessionSSOAuthenticator
 
     def profile_update(self, sso_session_id, data):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.black]
 line-length = 120
 skip-string-normalization = true
-target-version = ['py36']
+target-version = ['py39']
 include = '\.pyi?$'
 exclude = '''
 (

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_api_client',
-    version='26.2.0',
+    version='26.2.1',
     url='https://github.com/uktrade/directory-api-client',
     license='MIT',
     author='Department for International Trade',
@@ -12,15 +12,15 @@ setup(
     long_description_content_type='text/markdown',
     include_package_data=True,
     install_requires=[
-        'django>=2.2.10,<4.0.0',
+        'django>=3.2.18,<4.0.0',
         'requests>=2.22.0,<3.0.0',
-        'directory_client_core>=6.1.0,<8.0.0',
+        'directory_client_core>=7.1.1,<8.0.0',
     ],
     extras_require={
         'test': [
             'codecov==2.1.7',
             'pytest-cov==2.8.1',
-            'pytest==5.3.5',
+            'pytest==5.4.0',
             'requests_mock==1.7.0',
             'setuptools>=45.2.0,<50.0.0',
             'twine>=3.1.1,<4.0.0',


### PR DESCRIPTION
To do:

 - [X] Change has a jira ticket that has the correct status.
 - [X] Changelog entry added.
 - [X] Upgraded any vulnerable dependencies.
 