### PR TITLE
Remove changelog check from PR template & codecov update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,7 @@ jobs:
             . .venv/bin/activate
             pip install --upgrade pip
             make test_requirements
-            make pytest
-            codecov
+            make pytest_codecov -- --codecov-token=${CODECOV_TOKEN}
 
   flake8:
     docker:

--- a/makefile
+++ b/makefile
@@ -8,7 +8,16 @@ test_requirements:
 	pip install -e .[test]
 
 pytest:
-	pytest $(ARGUMENTS) --cov=. -v
+	pytest . --capture=no -vv
+
+pytest_codecov:
+	pytest \
+		--junitxml=test-reports/junit.xml \
+		--cov-config=.coveragerc \
+		--cov-report=term \
+		--cov=. \
+		--codecov \
+		$(ARGUMENTS)
 
 publish:
 	rm -rf build dist; \

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,9 +1,8 @@
 To do (delete all that do not apply):
 
  - [ ] Change has a jira ticket that has the correct status.
- - [ ] Changelog entry added.
+ - [ ] A clear description/pull request message has been added.
  - [ ] Fallback cache is not used on endpoints that lookup objects using sso session id
  - [ ] (if there are vulnerable requirements) Upgraded any vulnerable dependencies.
  - [ ] (if adding env vars) Added any new environment variable to vault.
  - [ ] (if adding feature flags) Cleaned up old flags
- 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_api_client',
-    version='26.2.1',
+    version='26.2.2',
     url='https://github.com/uktrade/directory-api-client',
     license='MIT',
     author='Department for International Trade',
@@ -18,9 +18,10 @@ setup(
     ],
     extras_require={
         'test': [
-            'codecov==2.1.7',
-            'pytest-cov==2.8.1',
+            'pytest-cov',
             'pytest==5.4.0',
+            'pytest-codecov',
+            'GitPython',
             'requests_mock==1.7.0',
             'setuptools>=45.2.0,<50.0.0',
             'twine>=3.1.1,<4.0.0',


### PR DESCRIPTION
This PR updates the PR template to no longer mention the changelog as we are no longer mantaining it.

To be able to unblock the CI pipeline, this PR also includes an update to our codecov configuration to use `pytest-codecov` rather than the outdated `codecov`

 - [x] Change has a jira ticket that has the correct status.