### PR TITLE
Bump django to 4.2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [26.4.0](https://pypi.org/project/directory-api-client/26.4.0/) (2023-07-03)
+
+- KLS-822 - Upgrade django version to Django 4.2.3
+
 ## [26.2.1](https://pypi.org/project/directory-api-client/26.2.1/) (2023-02-16)
 
 - KLS-400 - Upgrade vulnerable django version to Django 3.2.18

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_api_client',
-    version='26.3.0',
+    version='26.4.0',
     url='https://github.com/uktrade/directory-api-client',
     license='MIT',
     author='Department for International Trade',
@@ -12,7 +12,7 @@ setup(
     long_description_content_type='text/markdown',
     include_package_data=True,
     install_requires=[
-        'django>=3.2.18,<=4.2',
+        'django>=3.2.18,<=4.2.3',
         'requests>=2.22.0,<3.0.0',
         'directory_client_core>=7.1.1,<8.0.0',
     ],
@@ -43,6 +43,7 @@ setup(
         'Framework :: Django :: 3.1',
         'Framework :: Django :: 3.2',
         'Framework :: Django :: 4.1',
+        'Framework :: Django :: 4.2',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Natural Language :: English',


### PR DESCRIPTION
Bump django to 4.2.3 to allow great-magna-tests venerability to be patched. 

 - [x] Change has a jira ticket that has the correct status.
 - [x] A clear description/pull request message has been added.

