### PR TITLE
use v7.2.4 of directory-client-core

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [26.4.1](https://pypi.org/project/directory-api-client/26.4.1/) (2023-07-05)
+
+- KLS-822 - Use at least 7.2.4 of directory-client-core
+
 ## [26.4.0](https://pypi.org/project/directory-api-client/26.4.0/) (2023-07-03)
 
 - KLS-822 - Upgrade django version to Django 4.2.3

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_api_client',
-    version='26.4.0',
+    version='26.4.1',
     url='https://github.com/uktrade/directory-api-client',
     license='MIT',
     author='Department for International Trade',
@@ -14,7 +14,7 @@ setup(
     install_requires=[
         'django>=3.2.18,<=4.2.3',
         'requests>=2.22.0,<3.0.0',
-        'directory_client_core>=7.1.1,<8.0.0',
+        'directory_client_core>=7.2.4,<8.0.0',
     ],
     extras_require={
         'test': [


### PR DESCRIPTION
Use at least 7.2.4 of directory-client-core

 - [ ] Change has a jira ticket that has the correct status.
 - [ ] A clear description/pull request message has been added.

