### PR TITLE
bump Django version acceptance to 4.2.10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_api_client',
-    version='26.4.5',
+    version='26.4.6',
     url='https://github.com/uktrade/directory-api-client',
     license='MIT',
     author='Department for International Trade',
@@ -12,7 +12,7 @@ setup(
     long_description_content_type='text/markdown',
     include_package_data=True,
     install_requires=[
-        'django>=4.2.0,<=4.2.8',
+        'django>=4.2.0,<=4.2.10',
         'requests>=2.22.0,<3.0.0',
         'directory_client_core>=7.2.8,<8.0.0',
     ],


### PR DESCRIPTION
Bump Django acceptance to 4.2.10

 - [x] Change has a jira ticket that has the correct status. KLS-1951
