### PR TITLE
Upgrade/kls 1948 bump django 4.2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [26.4.12]() (2024-02-19)
+
+- KLS-1948 - Use at least 7.2.12 of directory-client-core
+
 ## [26.4.2](https://pypi.org/project/directory-api-client/26.4.2/) (2023-07-06)
 
 - KLS-822 - Use at least 7.2.5 of directory-client-core

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [26.4.12]() (2024-02-19)
+## [26.4.12](https://github.com/uktrade/directory-api-client/pull/179) (2024-02-19)
 
 - KLS-1948 - Use at least 7.2.12 of directory-client-core
 

--- a/setup.py
+++ b/setup.py
@@ -12,9 +12,9 @@ setup(
     long_description_content_type='text/markdown',
     include_package_data=True,
     install_requires=[
-        'django>=4.2.0,<=4.2.8',
+        'django>=4.2.10,<5.0',
         'requests>=2.22.0,<3.0.0',
-        'directory_client_core>=7.2.8,<8.0.0',
+        'directory_client_core>=7.2.12,<8.0.0',
     ],
     extras_require={
         'test': [

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_api_client',
-    version='26.4.5',
+    version='26.4.6',
     url='https://github.com/uktrade/directory-api-client',
     license='MIT',
     author='Department for International Trade',


### PR DESCRIPTION
Upgrade/kls 1948 bump django 4.2.10 minimum:


