### PR TITLE
ET-65 getter for markets data

### DIFF
--- a/directory_api_client/dataservices.py
+++ b/directory_api_client/dataservices.py
@@ -1,5 +1,6 @@
 from directory_api_client.base import AbstractAPIClient
 
+url_markets = 'dataservices/markets/'
 url_country_data_by_country = 'dataservices/country-data/'
 url_cia_world_factbook_data = 'dataservices/cia-factbook-data/'
 url_society_data_by_country = 'dataservices/society-data-by-country/'
@@ -18,6 +19,9 @@ url_business_cluster_information = 'dataservices/business-cluster-information/'
 
 
 class DataServicesAPIClient(AbstractAPIClient):
+    def get_markets_data(self):
+        return self.get(url=url_markets)
+
     def get_country_data_by_country(self, countries, fields):
         return self.get(url=url_country_data_by_country, params={'countries': countries, 'fields': fields})
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_api_client',
-    version='26.6.0',
+    version='26.6.1',
     url='https://github.com/uktrade/directory-api-client',
     license='MIT',
     author='Department for Business and Trade',

--- a/tests/test_dataservices.py
+++ b/tests/test_dataservices.py
@@ -13,6 +13,13 @@ def client():
     )
 
 
+def test_get_markets_data(client, requests_mock):
+    url = 'https://example.com/dataservices/markets/'
+    requests_mock.get(url)
+    client.get_markets_data()
+    assert requests_mock.last_request.url == url
+
+
 def test_get_country_data_by_country(client, requests_mock):
     url = 'https://example.com/dataservices/country-data/'
     requests_mock.get(url)


### PR DESCRIPTION
Add getter for markets data from directory-api

 - [x] Change has a jira ticket that has the correct status.
 - [x] A clear description/pull request message has been added.
