### PR TITLE
EYB-7 endpoints for statista salary/rent data

### DIFF
--- a/directory_api_client/dataservices.py
+++ b/directory_api_client/dataservices.py
@@ -17,6 +17,8 @@ url_economic_highlights = '/dataservices/economic-highlights/'
 url_uk_free_trade_agreements = '/dataservices/uk-free-trade-agreements/'
 url_business_cluster_information_by_sic = 'dataservices/business-cluster-information-by-sic/'
 url_business_cluster_information_by_dbt_sector = 'dataservices/business-cluster-information-by-dbt-sector/'
+url_eyb_salary_data = 'dataservices/eyb-salary-data/'
+url_eyb_commercial_rent_data = 'dataservices/eyb-commercial-rent-data/'
 
 
 class DataServicesAPIClient(AbstractAPIClient):
@@ -113,3 +115,25 @@ class DataServicesAPIClient(AbstractAPIClient):
             url=url_business_cluster_information_by_dbt_sector,
             params=params,
         )
+
+    def get_eyb_salary_data(self, geo_description, vertical=None, professional_level=None):
+        params = {'geo_description': geo_description}
+
+        if vertical:
+            params['vertical'] = vertical
+
+        if professional_level:
+            params['professional_level'] = professional_level
+
+        return self.get(url=url_eyb_salary_data, params=params)
+
+    def get_eyb_commercial_rent_data(self, geo_description, vertical=None, sub_vertical=None):
+        params = {'geo_description': geo_description}
+
+        if vertical:
+            params['vertical'] = vertical
+
+        if sub_vertical:
+            params['sub_vertical'] = sub_vertical
+
+        return self.get(url=url_eyb_commercial_rent_data, params=params)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_api_client',
-    version='26.6.1',
+    version='26.7.0',
     url='https://github.com/uktrade/directory-api-client',
     license='MIT',
     author='Department for Business and Trade',

--- a/tests/test_dataservices.py
+++ b/tests/test_dataservices.py
@@ -166,3 +166,51 @@ def test_business_cluster_information_dbt_sector_and_geo(requests_mock, client):
         requests_mock.last_request.url
         == f'{url}?dbt_sector_name=Financial+and+professional+services&geo_code=AB0001%2CXY12345'
     )
+
+
+def test_eyb_salary_geo_description(requests_mock, client):
+    url = 'https://example.com/dataservices/eyb-salary-data/'
+    requests_mock.get(url)
+    client.get_eyb_salary_data(geo_description='London')
+    assert requests_mock.last_request.url == f'{url}?geo_description=London'
+
+
+def test_eyb_salary_geo_description_vertical(requests_mock, client):
+    url = 'https://example.com/dataservices/eyb-salary-data/'
+    requests_mock.get(url)
+    client.get_eyb_salary_data(geo_description='London', vertical='Aerospace')
+    assert requests_mock.last_request.url == f'{url}?geo_description=London&vertical=Aerospace'
+
+
+def test_eyb_salary_geo_description_vertical_professional_level(requests_mock, client):
+    url = 'https://example.com/dataservices/eyb-salary-data/'
+    requests_mock.get(url)
+    client.get_eyb_salary_data(geo_description='London', vertical='Aerospace', professional_level='Entry-level')
+    assert (
+        requests_mock.last_request.url
+        == f'{url}?geo_description=London&vertical=Aerospace&professional_level=Entry-level'
+    )
+
+
+def test_eyb_commercial_rent_data_geo_description(requests_mock, client):
+    url = 'https://example.com/dataservices/eyb-commercial-rent-data/'
+    requests_mock.get(url)
+    client.get_eyb_commercial_rent_data(geo_description='London')
+    assert requests_mock.last_request.url == f'{url}?geo_description=London'
+
+
+def test_eyb_commercial_rent_data_geo_description_vertical(requests_mock, client):
+    url = 'https://example.com/dataservices/eyb-commercial-rent-data/'
+    requests_mock.get(url)
+    client.get_eyb_commercial_rent_data(geo_description='London', vertical='Industrial')
+    assert requests_mock.last_request.url == f'{url}?geo_description=London&vertical=Industrial'
+
+
+def test_eyb_commercial_rent_data_geo_description_vertical_sub_vertical(requests_mock, client):
+    url = 'https://example.com/dataservices/eyb-commercial-rent-data/'
+    requests_mock.get(url)
+    client.get_eyb_commercial_rent_data(geo_description='London', vertical='Industrial', sub_vertical='Large Warehouse')
+    assert (
+        requests_mock.last_request.url
+        == f'{url}?geo_description=London&vertical=Industrial&sub_vertical=Large+Warehouse'
+    )


### PR DESCRIPTION
Add endpoints to retrieve Statista salary and rent data from Directory API.

 - [x] Change has a jira ticket that has the correct status  https://uktrade.atlassian.net/browse/EYB-7
 - [x] A clear description/pull request message has been added.
