### PR TITLE
EYB-170: Update salary data parameter order

### DIFF
--- a/directory_api_client/dataservices.py
+++ b/directory_api_client/dataservices.py
@@ -116,14 +116,14 @@ class DataServicesAPIClient(AbstractAPIClient):
             params=params,
         )
 
-    def get_eyb_salary_data(self, geo_description, vertical=None, professional_level=None):
-        params = {'geo_description': geo_description}
-
-        if vertical:
-            params['vertical'] = vertical
+    def get_eyb_salary_data(self, vertical, professional_level=None, geo_description=None):
+        params = {'vertical': vertical}
 
         if professional_level:
             params['professional_level'] = professional_level
+
+        if geo_description:
+            params['geo_description'] = geo_description
 
         return self.get(url=url_eyb_salary_data, params=params)
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_api_client',
-    version='26.7.0',
+    version='26.7.1',
     url='https://github.com/uktrade/directory-api-client',
     license='MIT',
     author='Department for Business and Trade',

--- a/tests/test_dataservices.py
+++ b/tests/test_dataservices.py
@@ -168,27 +168,27 @@ def test_business_cluster_information_dbt_sector_and_geo(requests_mock, client):
     )
 
 
-def test_eyb_salary_geo_description(requests_mock, client):
+def test_eyb_salary_vertical(requests_mock, client):
     url = 'https://example.com/dataservices/eyb-salary-data/'
     requests_mock.get(url)
-    client.get_eyb_salary_data(geo_description='London')
-    assert requests_mock.last_request.url == f'{url}?geo_description=London'
+    client.get_eyb_salary_data(vertical='Advanced Engineering')
+    assert requests_mock.last_request.url == f'{url}?vertical=Advanced+Engineering'
 
 
 def test_eyb_salary_geo_description_vertical(requests_mock, client):
     url = 'https://example.com/dataservices/eyb-salary-data/'
     requests_mock.get(url)
-    client.get_eyb_salary_data(geo_description='London', vertical='Aerospace')
-    assert requests_mock.last_request.url == f'{url}?geo_description=London&vertical=Aerospace'
+    client.get_eyb_salary_data(vertical='Aerospace', geo_description='London')
+    assert requests_mock.last_request.url == f'{url}?vertical=Aerospace&geo_description=London'
 
 
 def test_eyb_salary_geo_description_vertical_professional_level(requests_mock, client):
     url = 'https://example.com/dataservices/eyb-salary-data/'
     requests_mock.get(url)
-    client.get_eyb_salary_data(geo_description='London', vertical='Aerospace', professional_level='Entry-level')
+    client.get_eyb_salary_data(vertical='Aerospace', professional_level='Entry-level', geo_description='London')
     assert (
         requests_mock.last_request.url
-        == f'{url}?geo_description=London&vertical=Aerospace&professional_level=Entry-level'
+        == f'{url}?vertical=Aerospace&professional_level=Entry-level&geo_description=London'
     )
 
 


### PR DESCRIPTION
This PR updates the parameter order of the GET Salary data endpoint. For further context refer to https://github.com/uktrade/directory-api/pull/1278


 - [x] Change has a jira ticket that has the correct status.
 - [x] A clear description/pull request message has been added.

