### PR TITLE
IGUK-220 add endpoint to retrieve gva bandings for all sectors

### DIFF
--- a/directory_api_client/dataservices.py
+++ b/directory_api_client/dataservices.py
@@ -21,6 +21,7 @@ url_eyb_salary_data = 'dataservices/eyb-salary-data/'
 url_eyb_commercial_rent_data = 'dataservices/eyb-commercial-rent-data/'
 url_dbt_sector = 'dataservices/dbt-sector/'
 url_sector_gva_value_band = 'dataservices/sector-gva-value-band/'
+url_all_sectors_gva_value_bands = 'dataservices/all-sectors-gva-value-bands/'
 url_dbt_investment_opportunity = 'dataservices/dbt-investment-opportunity/'
 
 
@@ -148,3 +149,6 @@ class DataServicesAPIClient(AbstractAPIClient):
         params = {'full_sector_name': full_sector_name}
 
         return self.get(url=url_sector_gva_value_band, params=params)
+
+    def get_all_sectors_gva_value_bands(self):
+        return self.get(url=url_all_sectors_gva_value_bands)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_api_client',
-    version='26.8.0',
+    version='26.9.0',
     url='https://github.com/uktrade/directory-api-client',
     license='MIT',
     author='Department for Business and Trade',

--- a/tests/test_dataservices.py
+++ b/tests/test_dataservices.py
@@ -228,3 +228,10 @@ def test_gva_bandings(requests_mock, client):
     requests_mock.get(url)
     client.get_gva_bandings(full_sector_name='Aerospace')
     assert requests_mock.last_request.url == f'{url}?full_sector_name=Aerospace'
+
+
+def test_(requests_mock, client):
+    url = 'https://example.com/dataservices/all-sectors-gva-value-bands/'
+    requests_mock.get(url)
+    client.get_all_sectors_gva_value_bands()
+    assert requests_mock.last_request.url == f'{url}'


### PR DESCRIPTION
PR to add an endpoint that retrieves GVA bandings for all sectors. Refer to [corresponding directory-api PR](https://github.com/uktrade/directory-api/pull/1305) for further details 

 - [x] Change has a jira ticket that has the correct status.
 - [x] A clear description/pull request message has been added.

