### PR TITLE
add endpoints for Country, Territory, Region dataset

### DIFF
--- a/directory_api_client/dataservices.py
+++ b/directory_api_client/dataservices.py
@@ -23,6 +23,8 @@ url_dbt_sector = 'dataservices/dbt-sector/'
 url_sector_gva_value_band = 'dataservices/sector-gva-value-band/'
 url_all_sectors_gva_value_bands = 'dataservices/all-sectors-gva-value-bands/'
 url_dbt_investment_opportunity = 'dataservices/dbt-investment-opportunity/'
+url_countries_territories_regions = 'dataservices/countries-territories-regions/'
+url_country_territory_region = 'dataservices/country-territory-region/'
 
 
 class DataServicesAPIClient(AbstractAPIClient):
@@ -152,3 +154,9 @@ class DataServicesAPIClient(AbstractAPIClient):
 
     def get_all_sectors_gva_value_bands(self):
         return self.get(url=url_all_sectors_gva_value_bands)
+
+    def get_all_countries_territories_regions(self):
+        return self.get(url=url_countries_territories_regions)
+
+    def get_country_territory_region(self, iso2_code: str) -> str:
+        return self.get(url=f'{url_country_territory_region}{iso2_code.upper()}')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_api_client',
-    version='26.11.0',
+    version='26.12.0',
     url='https://github.com/uktrade/directory-api-client',
     license='MIT',
     author='Department for Business and Trade',

--- a/tests/test_dataservices.py
+++ b/tests/test_dataservices.py
@@ -235,3 +235,17 @@ def test_(requests_mock, client):
     requests_mock.get(url)
     client.get_all_sectors_gva_value_bands()
     assert requests_mock.last_request.url == f'{url}'
+
+
+def test_countries_territories_regions(requests_mock, client):
+    url = 'https://example.com/dataservices/countries-territories-regions/'
+    requests_mock.get(url)
+    client.get_all_countries_territories_regions()
+    assert requests_mock.last_request.url == url
+
+
+def test_countries_territories_regions_single_country(requests_mock, client):
+    url = 'https://example.com/dataservices/country-territory-region/FR'
+    requests_mock.get(url)
+    client.get_country_territory_region(iso2_code='fr')
+    assert requests_mock.last_request.url == url


### PR DESCRIPTION
Add URLs for the new Country, Territory and Region endpoints in [this PR](https://github.com/uktrade/directory-api/pull/1321).

 - [x] Change has a jira ticket that has the correct status - https://uktrade.atlassian.net/browse/IGUK-381
 - [x] A clear description/pull request message has been added.

