### PR TITLE
BGST-169 - add news endpoint

### DIFF
--- a/directory_api_client/dataservices.py
+++ b/directory_api_client/dataservices.py
@@ -25,6 +25,7 @@ url_all_sectors_gva_value_bands = 'dataservices/all-sectors-gva-value-bands/'
 url_dbt_investment_opportunity = 'dataservices/dbt-investment-opportunity/'
 url_countries_territories_regions = 'dataservices/countries-territories-regions/'
 url_country_territory_region = 'dataservices/country-territory-region/'
+url_news_content = 'dataservices/news-content/'
 
 
 class DataServicesAPIClient(AbstractAPIClient):
@@ -160,3 +161,6 @@ class DataServicesAPIClient(AbstractAPIClient):
 
     def get_country_territory_region(self, iso2_code: str) -> str:
         return self.get(url=f'{url_country_territory_region}{iso2_code.upper()}')
+
+    def get_news_content(self):
+        return self.get(url=url_news_content)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='directory_api_client',
-    version='26.12.0',
+    version='26.13.0',
     url='https://github.com/uktrade/directory-api-client',
     license='MIT',
     author='Department for Business and Trade',

--- a/tests/test_dataservices.py
+++ b/tests/test_dataservices.py
@@ -249,3 +249,10 @@ def test_countries_territories_regions_single_country(requests_mock, client):
     requests_mock.get(url)
     client.get_country_territory_region(iso2_code='fr')
     assert requests_mock.last_request.url == url
+
+
+def test_get_news_content(requests_mock, client):
+    url = 'https://example.com/dataservices/news-content/'
+    requests_mock.get(url)
+    client.get_news_content()
+    assert requests_mock.last_request.url == url


### PR DESCRIPTION
To do (delete all that do not apply):

 - [x] Change has a jira ticket that has the correct status. https://uktrade.atlassian.net/browse/BGST-169
 - [x] A clear description/pull request message has been added.
 - See corresponding directory-api [PR](https://github.com/uktrade/directory-api/pull/1407)

